### PR TITLE
Add publication count to header

### DIFF
--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -333,6 +333,7 @@ function createBibLink(it){
   var els = {
     errors: document.getElementById('pubs-errors'),
     results: document.getElementById('pubs-results'),
+    count: document.getElementById('pubs-count'),
     filtersInteractive: document.getElementById('filters-interactive'),
     btnClear: document.getElementById('btn-clear'),
     years: document.getElementById('facet-years'),
@@ -777,11 +778,11 @@ updateFacetCounts(els.tyBox, 'types', tCounts, state.types);
 
   }
 
-function updateFacetCounts(mount, facetKey, countsMap, stateMap) {
-  var facet = mount._facet;
-  if (!facet) return;
+  function updateFacetCounts(mount, facetKey, countsMap, stateMap) {
+    var facet = mount._facet;
+    if (!facet) return;
 
-  var itemMap = facet.itemMap;
+    var itemMap = facet.itemMap;
   for (var val in itemMap) {
     var cnt = countsMap[val] || 0;
     var display = facet.labelFor ? facet.labelFor(val) : val;
@@ -794,12 +795,22 @@ function updateFacetCounts(mount, facetKey, countsMap, stateMap) {
   }
 }
 
+  function updatePublicationCount(count){
+    if (!els.count) return;
+    var label = (count === 1) ? '1 paper' : (count + ' papers');
+    els.count.textContent = '(' + label + ')';
+  }
+
+  updatePublicationCount(0);
+
   function applyFilters(){
     // recompute dynamic counts first (so user sees availability)
     updateDynamicCounts();
 
     // then produce final result set (include all active facets)
     var items = filteredItems(null);
+
+    updatePublicationCount(items.length);
 
     // sort by year desc, stable
     items.sort(function(a,b){

--- a/publications.html
+++ b/publications.html
@@ -131,7 +131,7 @@
           </div>
 
           <!-- PUBLICATIONS -->
-          <h2 class="grouphead">Publications</h2>
+          <h2 class="grouphead">Publications <span id="pubs-count"></span></h2>
           <div id="pubs-errors" class="switchversion" style="color:#b00;"></div>
           <div id="pubs-results"></div>
 


### PR DESCRIPTION
## Summary
- show the publications count next to the section header
- update the publications controller to keep the count in sync with the filtered results

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d41260a1648320a8d67f4e097d78c9